### PR TITLE
Scale plant ecology spawn rates with frame delta time

### DIFF
--- a/app.js
+++ b/app.js
@@ -1459,7 +1459,7 @@ import { FertilityGrid, attemptSeedDispersal, attemptSpontaneousGrowth, getResou
           }
           
           // Seed dispersal (resources spawn near existing ones)
-          const seedLocation = attemptSeedDispersal(World.resources, FertilityField, globalTick);
+          const seedLocation = attemptSeedDispersal(World.resources, FertilityField, globalTick, dt);
           if (seedLocation && World.resources.length < maxResources) {
             const newResource = new Resource(seedLocation.x, seedLocation.y, CONFIG.resourceRadius);
             World.resources.push(newResource);
@@ -1467,7 +1467,7 @@ import { FertilityGrid, attemptSeedDispersal, attemptSpontaneousGrowth, getResou
           }
           
           // Spontaneous growth (resources appear in fertile soil)
-          const growthLocation = attemptSpontaneousGrowth(FertilityField);
+          const growthLocation = attemptSpontaneousGrowth(FertilityField, dt);
           if (growthLocation && World.resources.length < maxResources) {
             const newResource = new Resource(growthLocation.x, growthLocation.y, CONFIG.resourceRadius);
             World.resources.push(newResource);

--- a/plantEcology.js
+++ b/plantEcology.js
@@ -252,15 +252,16 @@ export class FertilityGrid {
 /**
  * Seed dispersal - resources can spawn near existing ones
  */
-export function attemptSeedDispersal(resources, fertilityGrid, globalTick) {
+export function attemptSeedDispersal(resources, fertilityGrid, globalTick, dt) {
   const config = CONFIG.plantEcology;
   if (!config.enabled || resources.length === 0) return null;
-  
+
   // Random resource tries to spawn seed
   const parent = resources[Math.floor(Math.random() * resources.length)];
-  
+
   // Check spawn chance
-  if (Math.random() > config.seedChance) return null;
+  const seedChance = Math.min(1, config.seedChance * dt);
+  if (Math.random() > seedChance) return null;
   
   // Find location near parent
   const angle = Math.random() * Math.PI * 2;
@@ -290,12 +291,13 @@ export function attemptSeedDispersal(resources, fertilityGrid, globalTick) {
 /**
  * Spontaneous growth - resources can appear in fertile soil
  */
-export function attemptSpontaneousGrowth(fertilityGrid) {
+export function attemptSpontaneousGrowth(fertilityGrid, dt) {
   const config = CONFIG.plantEcology;
   if (!config.enabled) return null;
-  
+
   // Check growth chance
-  if (Math.random() > config.growthChance) return null;
+  const growthChance = Math.min(1, config.growthChance * dt);
+  if (Math.random() > growthChance) return null;
   
   // Find fertile location
   const location = fertilityGrid.findFertileSpawnLocation();


### PR DESCRIPTION
## Summary
- scale the seed dispersal and spontaneous growth probabilities by the per-frame delta time
- pass the frame delta time from the main loop into the plant ecology helpers

## Testing
- node test.js *(fails: requires a DOM environment for document.getElementById)*

------
https://chatgpt.com/codex/tasks/task_e_690a571bfa0c8333b1bdd271d1c2e3a3