### PR TITLE
refactor: Remove unused aiSenseCostPerSecond parameter

### DIFF
--- a/config.js
+++ b/config.js
@@ -115,7 +115,6 @@ export const CONFIG = {
   // === Sensing (smooth + delta-paid) ===
   aiSensoryRangeBase: 175,            // Reduced from 220 (tighter base vision)
   aiSensoryRangeMax: 360,             // Reduced from 560 (less popping)
-  aiSenseCostPerSecond: 1.0,
   aiSenseRangePerChi: 35,             // Reduced from 55 (83% more expensive!)
   aiSenseBiasFromFrustr: 0.8,
   aiSenseSlewPerSec: 380,
@@ -201,7 +200,7 @@ export const CONFIG = {
     headingNoise: 0.8,                // Radians of noise added to inherited heading
 
     // Discrete budding reproduction when χ is very high
-    buddingThreshold: 100,            // χ required to trigger budding split
+    buddingThreshold: 150,            // χ required to trigger budding split
     buddingShare: 0.5,                // Fraction of parent's χ transferred to budded child
     buddingOffset: 20,                // Random jitter radius for budding spawn (pixels)
     buddingRespectCooldown: true,     // Reuse cooldown before another budding/mitosis event


### PR DESCRIPTION
The `aiSenseCostPerSecond` parameter in `config.js` is unused. The cost for an AI agent to sense its environment is handled by the `Bundle.prototype.computeSensoryRange` function in `app.js`, which uses a more nuanced mechanism involving an immediate cost to expand its sensory range and an ongoing, quadratic 'holding cost' to maintain a range larger than the base. This commit removes the unused parameter to reduce confusion and improve the maintainability of the configuration.