### PR TITLE
Add signal analytics instrumentation and configurable signal tuning

### DIFF
--- a/analysis/signalResponseAnalytics.js
+++ b/analysis/signalResponseAnalytics.js
@@ -1,0 +1,145 @@
+const MAX_HISTORY = 2048;
+
+class ChannelTracker {
+  constructor() {
+    this.stimuli = [];
+    this.responses = [];
+    this.latencyHistory = [];
+    this.coherenceSum = 0;
+    this.responseCount = 0;
+    this.lastStimulusByAgent = new Map();
+    this.lastResponseTickByAgent = new Map();
+  }
+
+  pushStimulus(event) {
+    this.stimuli.push(event);
+    if (this.stimuli.length > MAX_HISTORY) {
+      this.stimuli.shift();
+    }
+    this.lastStimulusByAgent.set(event.agentId, event.tick);
+  }
+
+  pushResponse(event) {
+    this.responses.push(event);
+    if (this.responses.length > MAX_HISTORY) {
+      this.responses.shift();
+    }
+    if (typeof event.latency === 'number') {
+      this.latencyHistory.push(event.latency);
+      if (this.latencyHistory.length > MAX_HISTORY) {
+        this.latencyHistory.shift();
+      }
+    }
+    if (typeof event.alignment === 'number') {
+      this.coherenceSum += event.alignment;
+    }
+    this.responseCount += 1;
+    this.lastResponseTickByAgent.set(event.agentId, event.tick);
+  }
+
+  averageLatency() {
+    if (!this.latencyHistory.length) return 0;
+    const sum = this.latencyHistory.reduce((acc, v) => acc + v, 0);
+    return sum / this.latencyHistory.length;
+  }
+
+  averageCoherence() {
+    if (!this.responseCount) return 0;
+    return Math.max(0, Math.min(1, this.coherenceSum / this.responseCount));
+  }
+}
+
+export const SignalResponseAnalytics = {
+  _channels: new Map(),
+
+  _getChannel(channel) {
+    if (!this._channels.has(channel)) {
+      this._channels.set(channel, new ChannelTracker());
+    }
+    return this._channels.get(channel);
+  },
+
+  reset() {
+    this._channels.clear();
+  },
+
+  logStimulus(channel, tick, agentId, meta = {}) {
+    if (!channel && channel !== 0) return;
+    const tracker = this._getChannel(channel);
+    tracker.pushStimulus({
+      channel,
+      tick,
+      agentId,
+      amplitude: meta.amplitude ?? 0,
+      gradient: meta.gradient ?? 0
+    });
+  },
+
+  logResponse(channel, tick, agentId, meta = {}) {
+    if (!channel && channel !== 0) return;
+    const tracker = this._getChannel(channel);
+    const lastTick = tracker.lastResponseTickByAgent.get(agentId);
+    if (lastTick === tick) {
+      return; // Avoid duplicate logs in the same tick
+    }
+
+    const stimTick = tracker.lastStimulusByAgent.get(agentId);
+    const latency = typeof stimTick === 'number' ? Math.max(0, tick - stimTick) : undefined;
+
+    tracker.pushResponse({
+      channel,
+      tick,
+      agentId,
+      latency,
+      alignment: meta.alignment ?? 0,
+      magnitude: meta.magnitude ?? 0,
+      mode: meta.mode || 'unknown'
+    });
+  },
+
+  getSummary() {
+    const perChannel = {};
+    let totalStimuli = 0;
+    let totalResponses = 0;
+    let latencySum = 0;
+    let latencyCount = 0;
+    let coherenceSum = 0;
+
+    for (const [channel, tracker] of this._channels.entries()) {
+      const avgLatency = tracker.averageLatency();
+      const avgCoherence = tracker.averageCoherence();
+      const stimuliCount = tracker.stimuli.length;
+      const responseCount = tracker.responseCount;
+
+      perChannel[channel] = {
+        stimuli: stimuliCount,
+        responses: responseCount,
+        averageLatency: avgLatency,
+        coherence: avgCoherence
+      };
+
+      totalStimuli += stimuliCount;
+      totalResponses += responseCount;
+      if (tracker.latencyHistory.length) {
+        latencySum += tracker.latencyHistory.reduce((acc, v) => acc + v, 0);
+        latencyCount += tracker.latencyHistory.length;
+      }
+      coherenceSum += avgCoherence * responseCount;
+    }
+
+    const averageLatency = latencyCount ? latencySum / latencyCount : 0;
+    const averageCoherence = totalResponses ? coherenceSum / totalResponses : 0;
+
+    return {
+      totalStimuli,
+      totalResponses,
+      averageLatency,
+      coherence: Math.max(0, Math.min(1, averageCoherence)),
+      perChannel
+    };
+  }
+};
+
+if (typeof window !== 'undefined') {
+  window.SignalResponseAnalytics = SignalResponseAnalytics;
+}

--- a/config.js
+++ b/config.js
@@ -304,6 +304,23 @@ export const CONFIG = {
     decayPerSec: 0.06,
     diffusePerSec: 0.12,
     channels: 3,
+    memoryLength: 12,
+    activationThreshold: 0.08,
+    sensitivity: {
+      resource: 1.0,
+      distress: 1.0,
+      bond: 1.0
+    },
+    decay: {
+      resource: 0.08,
+      distress: 0.1,
+      bond: 0.06
+    },
+    channelWeights: {
+      resource: 1.0,
+      distress: 1.0,
+      bond: 1.0
+    }
   },
 
   // === Bond Loss Signals ===
@@ -551,6 +568,17 @@ export const CONFIG_SCHEMA = {
     "signal.decayPerSec": { label: "Signal decay/sec", min: 0, max: 1, step: 0.01 },
     "signal.diffusePerSec": { label: "Signal diffuse/sec", min: 0, max: 1, step: 0.01 },
     "signal.channels": { label: "Signal channels", min: 1, max: 8, step: 1 },
+    "signal.memoryLength": { label: "Signal memory length", min: 3, max: 120, step: 1 },
+    "signal.activationThreshold": { label: "Signal activation threshold", min: 0, max: 1, step: 0.01 },
+    "signal.sensitivity.resource": { label: "Resource sensitivity gain", min: 0, max: 5, step: 0.01 },
+    "signal.sensitivity.distress": { label: "Distress sensitivity gain", min: 0, max: 5, step: 0.01 },
+    "signal.sensitivity.bond": { label: "Bond sensitivity gain", min: 0, max: 5, step: 0.01 },
+    "signal.decay.resource": { label: "Resource bias decay", min: 0, max: 1, step: 0.01 },
+    "signal.decay.distress": { label: "Distress bias decay", min: 0, max: 1, step: 0.01 },
+    "signal.decay.bond": { label: "Bond bias decay", min: 0, max: 1, step: 0.01 },
+    "signal.channelWeights.resource": { label: "Resource channel weight", min: 0, max: 5, step: 0.01 },
+    "signal.channelWeights.distress": { label: "Distress channel weight", min: 0, max: 5, step: 0.01 },
+    "signal.channelWeights.bond": { label: "Bond channel weight", min: 0, max: 5, step: 0.01 },
   },
   "Bond Loss": {
     "bondLoss.onDeathExploreBoost": { label: "On-death explore boost", min: 0, max: 10, step: 0.01 },
@@ -782,6 +810,17 @@ const CONFIG_HINTS = {
   "signal.decayPerSec": "Per-second decay applied to signal strengths.",
   "signal.diffusePerSec": "Per-second diffusion rate between neighboring signal cells.",
   "signal.channels": "Number of independent signal channels to allocate.",
+  "signal.memoryLength": "Samples retained per channel for running averages and bias smoothing.",
+  "signal.activationThreshold": "Minimum amplitude/gradient to register a stimulus for analytics.",
+  "signal.sensitivity.resource": "Gain applied to resource-channel sampling before interpretation.",
+  "signal.sensitivity.distress": "Gain applied to distress-channel sampling before interpretation.",
+  "signal.sensitivity.bond": "Gain applied to bond-channel sampling before interpretation.",
+  "signal.decay.resource": "Per-tick decay factor for resource interpretation bias.",
+  "signal.decay.distress": "Per-tick decay factor for distress interpretation bias.",
+  "signal.decay.bond": "Per-tick decay factor for bond interpretation bias.",
+  "signal.channelWeights.resource": "Weight applied when resource signals steer agents.",
+  "signal.channelWeights.distress": "Weight applied when distress signals amplify exploration noise.",
+  "signal.channelWeights.bond": "Weight applied when bond signals dampen cooperative guidance.",
 
   // Bond loss
   "bondLoss.onDeathExploreBoost": "Exploration boost after a bonded partner dies.",

--- a/trainingUI.js
+++ b/trainingUI.js
@@ -76,6 +76,10 @@ export class TrainingUI {
         <div>Best Reward: <span id="stat-best">-</span></div>
         <div>Mean Reward: <span id="stat-mean">-</span></div>
         <div>Status: <span id="stat-status">Idle</span></div>
+        <div style="margin-top:8px;">Signal Diversity: <span id="stat-signal-diversity">-</span></div>
+        <div>Signal Coherence: <span id="stat-signal-coherence">-</span></div>
+        <div>Signal SNR: <span id="stat-signal-snr">-</span></div>
+        <div>Signal Power: <span id="stat-signal-power">-</span></div>
       </div>
     `;
     this.panel.appendChild(statsSection);
@@ -202,13 +206,39 @@ export class TrainingUI {
   // Update statistics
   updateStats(stats) {
     document.getElementById('stat-generation').textContent = stats.generation || 0;
-    document.getElementById('stat-policy').textContent = stats.currentPolicy !== undefined ? 
+    document.getElementById('stat-policy').textContent = stats.currentPolicy !== undefined ?
       `${stats.currentPolicy + 1}/${stats.populationSize}` : '-';
-    document.getElementById('stat-best').textContent = stats.bestReward ? 
+    document.getElementById('stat-best').textContent = stats.bestReward ?
       stats.bestReward.toFixed(2) : '-';
-    document.getElementById('stat-mean').textContent = stats.meanReward ? 
+    document.getElementById('stat-mean').textContent = stats.meanReward ?
       stats.meanReward.toFixed(2) : '-';
     document.getElementById('stat-status').textContent = stats.status || 'Idle';
+  }
+
+  updateSignalStats(signal) {
+    if (!signal) return;
+    const { channelCount = 0, diversity = 0, coherence = 0, snr = [], totalPower = [] } = signal;
+
+    const diversityEl = document.getElementById('stat-signal-diversity');
+    if (diversityEl) {
+      const ratio = channelCount ? `${diversity}/${channelCount}` : `${diversity}`;
+      diversityEl.textContent = ratio;
+    }
+
+    const coherenceEl = document.getElementById('stat-signal-coherence');
+    if (coherenceEl) {
+      coherenceEl.textContent = `${(coherence * 100).toFixed(1)}%`;
+    }
+
+    const snrEl = document.getElementById('stat-signal-snr');
+    if (snrEl) {
+      snrEl.textContent = snr.length ? snr.map((v, i) => `C${i}:${v.toFixed(2)}`).join(' ') : '-';
+    }
+
+    const powerEl = document.getElementById('stat-signal-power');
+    if (powerEl) {
+      powerEl.textContent = totalPower.length ? totalPower.map((v, i) => `C${i}:${v.toFixed(1)}`).join(' ') : '-';
+    }
   }
   
   // Show loaded policy info


### PR DESCRIPTION
## Summary
- maintain per-channel signal power, variance, and SNR in the signal field and expose them through a new stats helper
- add a lightweight analytics tracker for signal stimuli/response latencies and hook agent behaviors into it while respecting new sensitivity, decay, and weight settings
- extend the signal configuration schema and training UI to surface diversity, coherence, and SNR metrics for tuning feedback

## Testing
- not run (UI/analytics updates only)


------
https://chatgpt.com/codex/tasks/task_e_690cd47894708333aa2e39161aab6f34