### PR TITLE
Add TC snapshot schemas and placeholder universality profiles

### DIFF
--- a/analysis/manifest/tcSnapshotManifestExpectations.js
+++ b/analysis/manifest/tcSnapshotManifestExpectations.js
@@ -1,0 +1,28 @@
+const BASE_SCHEMA_PATH = '../../schemas/';
+
+export const tcSnapshotManifestExpectations = Object.freeze({
+  rule110: {
+    manifestType: 'tc.rule110.snapshot',
+    schema: `${BASE_SCHEMA_PATH}tc_rule110_snapshot.schema.json`,
+    requiredFields: ['type', 'tick', 'width', 'cells'],
+    description:
+      'Captures the binary cell pattern of a Rule 110 evolution step. Cells are serialized as 0/1 integers with optional metadata.',
+    optionalFields: ['origin', 'metadata']
+  },
+  turingTape: {
+    manifestType: 'tc.turing_tape.snapshot',
+    schema: `${BASE_SCHEMA_PATH}tc_tape_snapshot.schema.json`,
+    requiredFields: ['type', 'tick', 'head', 'tape'],
+    description:
+      'Captures a deterministic single-tape Turing machine configuration with head position/state and a finite tape window.',
+    optionalFields: ['window', 'metadata']
+  }
+});
+
+export function getTcSnapshotExpectation(key) {
+  return tcSnapshotManifestExpectations[key] ?? null;
+}
+
+export function listTcSnapshotManifestTypes() {
+  return Object.values(tcSnapshotManifestExpectations).map((entry) => entry.manifestType);
+}

--- a/profiles/universality/rule110.minimal.json
+++ b/profiles/universality/rule110.minimal.json
@@ -1,0 +1,16 @@
+{
+  "_comment": "Placeholder profile for Rule 110 universality experiments. Keeps TC plumbing disabled until ready.",
+  "tc": {
+    "_comment": "Disable by default; mode documents the intended snapshot source without activating it.",
+    "enabled": false,
+    "mode": "rule110",
+    "updateCadence": null,
+    "snapshots": {
+      "rule110": {
+        "_comment": "Manifests will conform to schemas/tc_rule110_snapshot.schema.json when enabled.",
+        "capture": false,
+        "schema": "schemas/tc_rule110_snapshot.schema.json"
+      }
+    }
+  }
+}

--- a/profiles/universality/turing_tape.minimal.json
+++ b/profiles/universality/turing_tape.minimal.json
@@ -1,0 +1,16 @@
+{
+  "_comment": "Placeholder profile for minimal single-tape Turing machine snapshots. Inactive but documents intended toggles.",
+  "tc": {
+    "_comment": "Explicitly disabled until tape capture is ready for runtime wiring.",
+    "enabled": false,
+    "mode": "turing_tape",
+    "updateCadence": null,
+    "snapshots": {
+      "turingTape": {
+        "_comment": "Manifests will follow schemas/tc_tape_snapshot.schema.json when recording is enabled.",
+        "capture": false,
+        "schema": "schemas/tc_tape_snapshot.schema.json"
+      }
+    }
+  }
+}

--- a/schemas/tc_rule110_snapshot.schema.json
+++ b/schemas/tc_rule110_snapshot.schema.json
@@ -1,0 +1,63 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://slimetest.local/schemas/tc_rule110_snapshot.schema.json",
+  "title": "TC Rule 110 Snapshot",
+  "description": "Snapshot of a Rule 110 cellular automaton state captured for TC manifest generation.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "type",
+    "tick",
+    "width",
+    "cells"
+  ],
+  "properties": {
+    "type": {
+      "const": "tc.rule110.snapshot",
+      "description": "Discriminator indicating the manifest payload represents a Rule 110 snapshot."
+    },
+    "tick": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Simulation tick when the snapshot was captured."
+    },
+    "width": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "Number of cells tracked for this snapshot frame."
+    },
+    "cells": {
+      "type": "array",
+      "minItems": 1,
+      "description": "Ordered binary cell states for the captured frame (0 = inactive, 1 = active).",
+      "items": {
+        "type": "integer",
+        "enum": [0, 1]
+      }
+    },
+    "origin": {
+      "type": "string",
+      "description": "Optional tag describing how the initial configuration was seeded."
+    },
+    "metadata": {
+      "type": "object",
+      "description": "Optional authoring metadata surfaced alongside the manifest payload.",
+      "additionalProperties": false,
+      "properties": {
+        "rule": {
+          "type": "integer",
+          "const": 110,
+          "description": "Rule identifier, fixed at 110 for this schema."
+        },
+        "seed": {
+          "type": ["string", "integer"],
+          "description": "Identifier or numeric seed used to generate the initial cell configuration."
+        },
+        "notes": {
+          "type": "string",
+          "description": "Free-form notes describing the captured state."
+        }
+      }
+    }
+  }
+}

--- a/schemas/tc_tape_snapshot.schema.json
+++ b/schemas/tc_tape_snapshot.schema.json
@@ -1,0 +1,96 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://slimetest.local/schemas/tc_tape_snapshot.schema.json",
+  "title": "TC Turing Tape Snapshot",
+  "description": "Snapshot of a single-tape deterministic Turing machine state for manifest recording.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "type",
+    "tick",
+    "head",
+    "tape"
+  ],
+  "properties": {
+    "type": {
+      "const": "tc.turing_tape.snapshot",
+      "description": "Discriminator indicating a Turing tape snapshot payload."
+    },
+    "tick": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Simulation tick associated with the snapshot."
+    },
+    "head": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "position",
+        "state"
+      ],
+      "properties": {
+        "position": {
+          "type": "integer",
+          "description": "Current integer position of the head on the tape (0 = origin)."
+        },
+        "state": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Identifier of the Turing machine control state."
+        },
+        "halted": {
+          "type": "boolean",
+          "description": "Flag indicating whether the machine is in a halting configuration."
+        },
+        "direction": {
+          "type": "string",
+          "enum": ["L", "R", "N"],
+          "description": "Last movement direction (Left, Right, or None)."
+        }
+      }
+    },
+    "tape": {
+      "type": "array",
+      "minItems": 1,
+      "description": "Finite view of the tape contents centered around the origin index.",
+      "items": {
+        "type": ["string", "integer"],
+        "description": "Symbols emitted on the tape (commonly 0/1 or blank markers)."
+      }
+    },
+    "window": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "start",
+        "end"
+      ],
+      "properties": {
+        "start": {
+          "type": "integer",
+          "description": "Inclusive index of the first cell represented in the tape array."
+        },
+        "end": {
+          "type": "integer",
+          "description": "Exclusive index immediately after the last cell represented in the tape array."
+        }
+      },
+      "description": "Optional bounds describing how the finite tape view maps onto the infinite tape coordinates."
+    },
+    "metadata": {
+      "type": "object",
+      "description": "Optional annotation surfaced alongside the manifest payload.",
+      "additionalProperties": false,
+      "properties": {
+        "machineId": {
+          "type": "string",
+          "description": "Identifier of the machine configuration used to generate the snapshot."
+        },
+        "notes": {
+          "type": "string",
+          "description": "Free-form notes for operators reviewing the manifest."
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add JSON schemas for Rule 110 and Turing tape TC snapshot payloads
- document manifest expectations for the new TC snapshot types
- stage inert universality profiles that reference the new schemas and toggles

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_690d25ac6dcc8333b321e45ff49b57c3