### PR TITLE
Create src entry point and add scaffolding docs

### DIFF
--- a/index.html
+++ b/index.html
@@ -138,6 +138,6 @@
     <div class="hotkey-item"><span class="hotkey-key">Ctrl+U</span><span class="hotkey-desc">Revert Config</span></div>
   </div>
   <canvas id="view"></canvas>
-  <script type="module" src="app.js"></script>
+  <script type="module" src="src/index.js"></script>
 </body>
 </html>

--- a/src/README.md
+++ b/src/README.md
@@ -1,0 +1,3 @@
+# src
+
+This directory will house the modularized source code for the slime simulation. For now it only contains the compatibility entry point in `index.js`, but future agents should migrate the legacy scripts here in a structured way.

--- a/src/core/README.md
+++ b/src/core/README.md
@@ -1,0 +1,3 @@
+# src/core
+
+Use this folder for fundamental simulation primitives such as world state containers, configuration helpers, and shared utility modules that don't depend on higher-level systems.

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,7 @@
+// Temporary module bridge for the legacy app entrypoint.
+// Loads the existing app.js side effects and re-exports its window globals.
+import '../app.js';
+
+export const World = window.World;
+export const resizeCanvas = window.resizeCanvas;
+export const trainingUI = window.trainingUI;

--- a/src/systems/README.md
+++ b/src/systems/README.md
@@ -1,0 +1,3 @@
+# src/systems
+
+Plan to collect simulation systems here: sensing, movement, rewards, ecology, and other domain-specific logic that orchestrates the agents' behavior.

--- a/src/ui/README.md
+++ b/src/ui/README.md
@@ -1,0 +1,3 @@
+# src/ui
+
+Reserve this folder for interface code: rendering helpers, control panels, overlays, and any components that manage user interaction with the simulation.


### PR DESCRIPTION
## Summary
- add a src/index.js module that loads the legacy app and re-exports its globals
- document the new src folder layout with placeholder README files
- update index.html to point at the new entry module

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e1ac11cc48333915fc24e641f4170)