### PR TITLE
Refactor canvas and input handling into UI managers

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,10 @@
 // Loads the existing app.js side effects and re-exports its window globals.
 import '../app.js';
 
+if (typeof window !== 'undefined' && typeof window.resizeCanvas === 'function') {
+  window.resizeCanvas();
+}
+
 export const World = window.World;
 export const resizeCanvas = window.resizeCanvas;
 export const trainingUI = window.trainingUI;

--- a/src/ui/canvasManager.js
+++ b/src/ui/canvasManager.js
@@ -1,0 +1,61 @@
+export function initializeCanvasManager({ canvas, ctx, getAvailableSize }) {
+  if (!canvas) {
+    throw new Error('initializeCanvasManager requires a canvas element');
+  }
+
+  let dpr = 1;
+  let canvasWidth = typeof window !== 'undefined' ? window.innerWidth : canvas?.width || 0;
+  let canvasHeight = typeof window !== 'undefined' ? window.innerHeight : canvas?.height || 0;
+  const resizeCallbacks = new Set();
+
+  const applyResize = () => {
+    if (typeof window !== 'undefined') {
+      dpr = Math.max(1, Math.min(window.devicePixelRatio || 1, 3));
+    }
+
+    const size = typeof getAvailableSize === 'function'
+      ? getAvailableSize()
+      : { width: canvasWidth, height: canvasHeight };
+
+    canvasWidth = size?.width ?? canvasWidth;
+    canvasHeight = size?.height ?? canvasHeight;
+
+    const targetWidth = Math.floor(canvasWidth * dpr);
+    const targetHeight = Math.floor(canvasHeight * dpr);
+
+    if (canvas.width !== targetWidth) canvas.width = targetWidth;
+    if (canvas.height !== targetHeight) canvas.height = targetHeight;
+
+    if (ctx) {
+      ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+    }
+
+    if (canvas.style) {
+      canvas.style.width = `${canvasWidth}px`;
+      canvas.style.height = `${canvasHeight}px`;
+      canvas.style.position = 'fixed';
+      canvas.style.top = '0';
+      canvas.style.left = '0';
+    }
+
+    for (const callback of resizeCallbacks) {
+      callback({ width: canvasWidth, height: canvasHeight, dpr, canvas, ctx });
+    }
+  };
+
+  if (typeof window !== 'undefined') {
+    window.addEventListener('resize', applyResize, { passive: true });
+  }
+
+  const onResize = (callback) => {
+    if (typeof callback === 'function') {
+      resizeCallbacks.add(callback);
+      return () => resizeCallbacks.delete(callback);
+    }
+    return () => {};
+  };
+
+  const getState = () => ({ width: canvasWidth, height: canvasHeight, dpr });
+
+  return { resizeCanvas: applyResize, onResize, getState };
+}

--- a/src/ui/inputManager.js
+++ b/src/ui/inputManager.js
@@ -1,0 +1,163 @@
+const movementKeys = [
+  'arrowup',
+  'w',
+  'arrowdown',
+  's',
+  'arrowleft',
+  'a',
+  'arrowright',
+  'd'
+];
+
+export function initializeInputManager({
+  canvas,
+  getWorld,
+  getTrail,
+  getSignalField,
+  getTrainingUI,
+  CONFIG
+}) {
+  const held = new Set();
+  const state = {
+    showScentGradient: true,
+    showFertility: false,
+    hudDisplayMode: 'full',
+    showAgentDashboard: false
+  };
+  let showHotkeyStrip = true;
+
+  const handleKeydown = (event) => {
+    const e = event || window.event;
+    const key = e.key.toLowerCase();
+    if (movementKeys.includes(key)) {
+      held.add(key);
+    }
+
+    const world = typeof getWorld === 'function' ? getWorld() : undefined;
+    const trail = typeof getTrail === 'function' ? getTrail() : undefined;
+    const signalField = typeof getSignalField === 'function' ? getSignalField() : undefined;
+    const trainingUI = typeof getTrainingUI === 'function' ? getTrainingUI() : undefined;
+
+    switch (e.code) {
+      case 'Space':
+        if (world) {
+          world.paused = !world.paused;
+          e.preventDefault();
+        }
+        break;
+      case 'KeyR':
+        world?.reset();
+        break;
+      case 'KeyK': {
+        showHotkeyStrip = !showHotkeyStrip;
+        const hotkeyStrip = document.getElementById('hotkey-strip');
+        if (hotkeyStrip) {
+          hotkeyStrip.classList.toggle('hidden', !showHotkeyStrip);
+        }
+        console.log(`⌨️  Hotkey strip ${showHotkeyStrip ? 'VISIBLE' : 'HIDDEN'}`);
+        e.preventDefault();
+        break;
+      }
+      case 'KeyC':
+        world?.bundles?.forEach((bundle) => {
+          bundle.chi += 5;
+          bundle.alive = true;
+          bundle.deathTick = -1;
+          bundle.decayProgress = 0;
+        });
+        break;
+      case 'KeyS':
+        world?.bundles?.forEach((bundle) => {
+          bundle.extendedSensing = !bundle.extendedSensing;
+        });
+        break;
+      case 'KeyT':
+        if (CONFIG) CONFIG.renderTrail = !CONFIG.renderTrail;
+        break;
+      case 'KeyX':
+        trail?.clear?.();
+        signalField?.clear?.();
+        break;
+      case 'KeyF':
+        if (CONFIG) CONFIG.enableDiffusion = !CONFIG.enableDiffusion;
+        break;
+      case 'KeyA':
+        if (CONFIG) CONFIG.autoMove = !CONFIG.autoMove;
+        break;
+      case 'KeyL':
+        trainingUI?.toggle?.();
+        break;
+      case 'KeyG':
+        state.showScentGradient = !state.showScentGradient;
+        break;
+      case 'KeyM':
+        if (CONFIG?.mitosis) {
+          CONFIG.mitosis.enabled = !CONFIG.mitosis.enabled;
+          console.log(`🧫 Mitosis ${CONFIG.mitosis.enabled ? 'ENABLED' : 'DISABLED'}`);
+        }
+        break;
+      case 'KeyP':
+        state.showFertility = !state.showFertility;
+        break;
+      case 'KeyH':
+        state.showAgentDashboard = !state.showAgentDashboard;
+        break;
+      case 'KeyU':
+        if (state.hudDisplayMode === 'full') state.hudDisplayMode = 'minimal';
+        else if (state.hudDisplayMode === 'minimal') state.hudDisplayMode = 'hidden';
+        else state.hudDisplayMode = 'full';
+        console.log(`📊 HUD mode: ${state.hudDisplayMode.toUpperCase()}`);
+        break;
+      case 'Digit1':
+      case 'Digit2':
+      case 'Digit3':
+      case 'Digit4': {
+        const index = Number(e.code.replace('Digit', '')) - 1;
+        const bundle = world?.bundles?.[index];
+        if (bundle) bundle.visible = !bundle.visible;
+        break;
+      }
+      case 'KeyV':
+        world?.bundles?.forEach((bundle) => {
+          bundle.visible = !bundle.visible;
+        });
+        break;
+      case 'KeyE':
+        if (canvas) {
+          e.preventDefault();
+          canvas.toBlob((blob) => {
+            if (!blob) return;
+            const url = URL.createObjectURL(blob);
+            const timestamp = new Date().toISOString().replace(/[:.]/g, '-').slice(0, -5);
+            const filename = `slime-screenshot-${timestamp}.png`;
+            const link = document.createElement('a');
+            link.href = url;
+            link.download = filename;
+            document.body.appendChild(link);
+            link.click();
+            document.body.removeChild(link);
+            URL.revokeObjectURL(url);
+            console.log(`📸 Screenshot saved: ${filename}`);
+          }, 'image/png');
+        }
+        break;
+      default:
+        break;
+    }
+  };
+
+  const handleKeyup = (event) => {
+    const key = event.key.toLowerCase();
+    held.delete(key);
+  };
+
+  window.addEventListener('keydown', handleKeydown);
+  window.addEventListener('keyup', handleKeyup);
+
+  const dispose = () => {
+    window.removeEventListener('keydown', handleKeydown);
+    window.removeEventListener('keyup', handleKeyup);
+  };
+
+  return { held, state, dispose };
+}


### PR DESCRIPTION
## Summary
- extract DPR-aware canvas sizing into src/ui/canvasManager.js and reuse it inside the legacy app
- move keyboard controls into src/ui/inputManager.js while keeping shared state accessible to the simulation
- trigger an initial resize from src/index.js to keep the entrypoint aligned with the new helpers

## Testing
- not run (browser interaction required)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e2d9573308333bd0b75cdac12a726)