### PR TITLE
Refactor simulation scheduling and training helpers

### DIFF
--- a/src/core/simulationLoop.js
+++ b/src/core/simulationLoop.js
@@ -1,0 +1,171 @@
+const DEFAULT_MAX_DELTA = 0.1;
+
+function defaultNow() {
+  if (typeof performance !== 'undefined' && typeof performance.now === 'function') {
+    return performance.now();
+  }
+  return Date.now();
+}
+
+function defaultRequestFrame(callback) {
+  if (typeof requestAnimationFrame === 'function') {
+    return requestAnimationFrame(callback);
+  }
+  return setTimeout(() => callback(defaultNow()), 16);
+}
+
+function defaultCancelFrame(handle) {
+  if (typeof cancelAnimationFrame === 'function') {
+    cancelAnimationFrame(handle);
+    return;
+  }
+  clearTimeout(handle);
+}
+
+/**
+ * Executes the provided simulation phases for a single tick.
+ *
+ * @param {Object} options
+ * @param {number} options.dt - Delta time in seconds for this step.
+ * @param {string} options.mode - Current execution mode (e.g., 'play' or 'train').
+ * @param {Function} [options.beginTick] - Optional hook invoked before phases run.
+ *   Receives { dt, mode } and should return an opaque context (e.g., scheduler handle).
+ * @param {Function[]} options.phases - Ordered callbacks invoked to advance the simulation.
+ *   Each phase receives { dt, mode, tickContext }.
+ * @param {Function} [options.endTick] - Optional hook invoked after phases run.
+ * @param {Function} [options.onError] - Called when a phase throws.
+ */
+export function performSimulationStep({
+  dt,
+  mode,
+  beginTick,
+  phases,
+  endTick,
+  onError
+}) {
+  if (!Array.isArray(phases)) {
+    throw new Error('performSimulationStep requires an array of phases');
+  }
+
+  const tickContext = typeof beginTick === 'function'
+    ? beginTick({ dt, mode })
+    : undefined;
+
+  const phaseState = { dt, mode, tickContext };
+
+  try {
+    for (const phase of phases) {
+      if (typeof phase !== 'function') continue;
+      phase(phaseState);
+    }
+  } catch (error) {
+    if (typeof onError === 'function') {
+      onError(error, phaseState);
+    } else {
+      throw error;
+    }
+  } finally {
+    if (typeof endTick === 'function' && tickContext !== undefined) {
+      endTick(tickContext);
+    }
+  }
+}
+
+/**
+ * Starts a render-driven simulation loop using requestAnimationFrame (or a fallback).
+ *
+ * @param {Object} options
+ * @param {Function} options.shouldStep - Returns true when the simulation should advance.
+ * @param {Function} options.getMode - Returns the current execution mode string.
+ * @param {Function} options.getPhases - Returns the ordered phase callbacks for the provided mode.
+ *   Signature: (mode) => Function[]
+ * @param {Function} [options.beginTick]
+ * @param {Function} [options.endTick]
+ * @param {Function} [options.draw] - Called every frame after updates with { dt, mode, now }.
+ * @param {Function} [options.onError]
+ * @param {Function} [options.requestFrame]
+ * @param {Function} [options.cancelFrame]
+ * @param {Function} [options.now]
+ * @param {number} [options.maxDelta]
+ * @returns {Function} stop function to cancel the loop.
+ */
+export function startSimulation({
+  shouldStep,
+  getMode,
+  getPhases,
+  beginTick,
+  endTick,
+  draw,
+  onError,
+  requestFrame = defaultRequestFrame,
+  cancelFrame = defaultCancelFrame,
+  now = defaultNow,
+  maxDelta = DEFAULT_MAX_DELTA
+}) {
+  if (typeof shouldStep !== 'function') {
+    throw new Error('startSimulation requires a shouldStep function');
+  }
+  if (typeof getMode !== 'function') {
+    throw new Error('startSimulation requires a getMode function');
+  }
+  if (typeof getPhases !== 'function') {
+    throw new Error('startSimulation requires a getPhases function');
+  }
+
+  let last = now();
+  let frameHandle = null;
+  let stopped = false;
+
+  const frame = (timestamp) => {
+    if (stopped) {
+      return;
+    }
+
+    frameHandle = requestFrame(frame);
+    const dtMs = timestamp - last;
+    last = timestamp;
+    const dt = Math.min(maxDelta, Math.max(0, dtMs) / 1000);
+    const mode = getMode();
+
+    try {
+      if (shouldStep()) {
+        const phases = getPhases(mode) || [];
+        performSimulationStep({
+          dt,
+          mode,
+          beginTick,
+          phases,
+          endTick,
+          onError
+        });
+      }
+    } catch (error) {
+      if (typeof onError === 'function') {
+        onError(error, { dt, mode });
+      } else {
+        console.error('Simulation loop error:', error);
+      }
+    }
+
+    if (typeof draw === 'function') {
+      try {
+        draw({ dt, mode, now: timestamp });
+      } catch (error) {
+        if (typeof onError === 'function') {
+          onError(error, { dt, mode, phase: 'draw' });
+        } else {
+          console.error('Simulation draw error:', error);
+        }
+      }
+    }
+  };
+
+  frameHandle = requestFrame(frame);
+
+  return () => {
+    if (!stopped && frameHandle !== null) {
+      stopped = true;
+      cancelFrame(frameHandle);
+    }
+  };
+}

--- a/src/core/training.js
+++ b/src/core/training.js
@@ -1,0 +1,448 @@
+import { performSimulationStep } from './simulationLoop.js';
+
+export function createTrainingModule({
+  world,
+  config,
+  trail,
+  signalField,
+  tcScheduler,
+  ledger,
+  episodeManager,
+  learner,
+  TrainingManagerClass,
+  TrainingUIClass,
+  normalizeRewardSignal,
+  updateFindTimeEMA,
+  calculateAdaptiveReward,
+  getGlobalTick,
+  incrementGlobalTick,
+  setWorldPaused,
+  onLearningModeChange,
+  windowHandle = typeof window !== 'undefined' ? window : null,
+  documentHandle = typeof document !== 'undefined' ? document : null
+}) {
+  if (!world || !config || !trail || !signalField || !tcScheduler || !episodeManager) {
+    throw new Error('createTrainingModule requires core simulation dependencies');
+  }
+
+  let learningMode = 'play';
+  let trainingManager = null;
+  let stopTrainingFlag = false;
+  let loadedPolicyInfo = null;
+
+  function getLearningMode() {
+    return learningMode;
+  }
+
+  function setLearningMode(mode) {
+    learningMode = mode;
+    if (typeof onLearningModeChange === 'function') {
+      onLearningModeChange(mode);
+    }
+  }
+
+  function ensureTrainingManager() {
+    if (!TrainingManagerClass || !learner) {
+      return null;
+    }
+    if (!trainingManager) {
+      trainingManager = new TrainingManagerClass(
+        learner,
+        () => world.reset(),
+        (policy) => runEpisode(policy)
+      );
+    }
+    return trainingManager;
+  }
+
+  function getTcContextFactory(mode) {
+    return ({ dt }) => {
+      const config = tcScheduler.getConfig();
+      if (!config || !config.enabled) {
+        return null;
+      }
+      return tcScheduler.beginTick({
+        tick: typeof getGlobalTick === 'function' ? getGlobalTick() : 0,
+        dt,
+        mode,
+        scheduler: mode === 'train' ? 'episode' : 'play',
+        world
+      });
+    };
+  }
+
+  async function runEpisode(policy) {
+    if (!policy) {
+      throw new Error('runEpisode requires a policy');
+    }
+
+    world.reset();
+    episodeManager.startEpisode();
+
+    world.bundles.forEach((bundle) => {
+      bundle.controller = policy;
+      bundle.useController = true;
+      bundle.rewardTracker.reset();
+    });
+
+    ledger.credits = {};
+
+    let totalReward = 0;
+    let episodeTicks = 0;
+    const maxTicks = config.learning.episodeLength;
+
+    const capturePhase = ({ tickContext }) => {
+      trail.captureSnapshot();
+      if (config.signal.enabled) {
+        signalField.captureSnapshot();
+      }
+      if (tickContext) {
+        tcScheduler.runPhase('capture', tickContext);
+      }
+    };
+
+    const updateAgentsPhase = ({ dt, tickContext }) => {
+      let totalChiSpent = 0;
+      for (let i = 0; i < world.bundles.length; i++) {
+        const bundle = world.bundles[i];
+        if (!bundle.alive) continue;
+
+        const chiBeforeUpdate = bundle.chi;
+        const nearestResource = world.getNearestResource(bundle);
+        bundle.update(dt, nearestResource);
+
+        const chiSpent = Math.max(0, chiBeforeUpdate - bundle.chi);
+        totalChiSpent += chiSpent;
+
+        let collectedResource = false;
+        for (const res of world.resources) {
+          if (!(bundle.alive && res.visible && bundle.overlapsResource(res))) continue;
+
+          let rewardChi;
+          if (config.adaptiveReward?.enabled) {
+            const dtFind = updateFindTimeEMA(world);
+            rewardChi = calculateAdaptiveReward(world.avgFindTime);
+            world.rewardStats.totalRewards += rewardChi;
+            world.rewardStats.avgRewardGiven = world.rewardStats.totalRewards / (world.collected + 1);
+            if (world.collected % 10 === 0 && world.collected > 0) {
+              console.log(`[Adaptive Reward] Find #${world.collected}: dt=${dtFind.toFixed(2)}s, avgT=${world.avgFindTime.toFixed(2)}s, reward=${rewardChi.toFixed(2)}χ`);
+            }
+          } else {
+            rewardChi = config.rewardChi;
+          }
+
+          bundle.chi += rewardChi;
+          bundle.alive = true;
+          bundle.lastCollectTick = typeof getGlobalTick === 'function' ? getGlobalTick() : 0;
+          bundle.frustration = 0;
+          bundle.hunger = Math.max(0, bundle.hunger - config.hungerDecayOnCollect);
+          bundle.deathTick = -1;
+          bundle.decayProgress = 0;
+          const rewardSignal = normalizeRewardSignal(rewardChi);
+          if (rewardSignal > 0) {
+            bundle.emitSignal('resource', rewardSignal, { absolute: true, x: bundle.x, y: bundle.y });
+          }
+
+          world.collected += 1;
+          world.onResourceCollected();
+          res.startCooldown();
+          collectedResource = true;
+          break;
+        }
+
+        const provenanceCredit = ledger.getCredits(bundle.id);
+        const stepReward = bundle.rewardTracker.computeStepReward(
+          collectedResource,
+          totalChiSpent,
+          provenanceCredit,
+          world.resources
+        );
+        totalReward += stepReward;
+      }
+
+      if (tickContext) {
+        tcScheduler.runPhase('compute', tickContext);
+      }
+    };
+
+    const environmentPhase = ({ dt, tickContext }) => {
+      trail.step(dt);
+      if (config.signal.enabled) {
+        signalField.step(dt);
+      }
+      if (tickContext) {
+        tcScheduler.runPhase('commit', tickContext);
+      }
+    };
+
+    const endPhase = () => {
+      if (typeof incrementGlobalTick === 'function') {
+        incrementGlobalTick();
+      }
+      episodeTicks += 1;
+    };
+
+    while (episodeTicks < maxTicks && world.bundles.some((b) => b.alive)) {
+      const dt = 1 / 60;
+      const beginTick = getTcContextFactory('train');
+      performSimulationStep({
+        dt,
+        mode: 'train',
+        beginTick,
+        phases: [capturePhase, updateAgentsPhase, environmentPhase, endPhase],
+        endTick: (ctx) => {
+          if (ctx) {
+            tcScheduler.endTick(ctx);
+          }
+        },
+        onError: (err) => {
+          console.error('Error in training step:', err);
+          throw err;
+        }
+      });
+
+      if (episodeTicks % 100 === 0) {
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      }
+    }
+
+    for (const bundle of world.bundles) {
+      if (!bundle.alive && episodeTicks < maxTicks) {
+        totalReward += config.learning.rewards.death;
+      }
+    }
+
+    episodeManager.endEpisode(world.bundles[0]?.rewardTracker);
+    return totalReward;
+  }
+
+  function initializeTrainingUI() {
+    if (!TrainingUIClass || !learner || !documentHandle) {
+      return;
+    }
+
+    const ui = new TrainingUIClass(documentHandle.body);
+    if (windowHandle) {
+      windowHandle.trainingUI = ui;
+    }
+
+    ui.on('onModeChange', (mode) => {
+      setLearningMode(mode);
+      if (mode === 'train') {
+        console.log('Switched to Training Mode');
+        world.bundles.forEach((b) => (b.useController = true));
+      } else {
+        console.log('Switched to Play Mode');
+        world.bundles.forEach((b) => (b.useController = false));
+      }
+    });
+
+    ui.on('onStartTraining', async (numGenerations) => {
+      const manager = ensureTrainingManager();
+      if (!manager) return;
+
+      stopTrainingFlag = false;
+
+      console.log(`🤝 Multi-Agent Training Starting: ALL ${world.bundles.length} agents use shared policy`);
+      console.log('   Episode reward = Sum of all agent rewards');
+      console.log('   Agents can learn cooperation via trails and provenance credits!');
+
+      ui.updateStats({
+        status: 'Multi-Agent Training...',
+        generation: learner.generation,
+        populationSize: config.learning.populationSize
+      });
+
+      if (typeof setWorldPaused === 'function') {
+        setWorldPaused(true);
+      }
+
+      for (let gen = 0; gen < numGenerations; gen++) {
+        if (stopTrainingFlag) {
+          console.log('Training stopped by user');
+          break;
+        }
+
+        const result = await manager.runGeneration();
+
+        ui.updateStats({
+          status: `Gen ${result.generation}/${numGenerations}`,
+          generation: result.generation,
+          bestReward: result.bestReward,
+          meanReward: result.meanReward,
+          currentPolicy: manager.currentPolicy,
+          populationSize: config.learning.populationSize
+        });
+
+        const stats = learner.getStats();
+        if (stats) {
+          ui.drawLearningCurve(stats.history);
+        }
+
+        console.log(`Gen ${result.generation}: best=${result.bestReward.toFixed(2)}, mean=${result.meanReward.toFixed(2)}`);
+      }
+
+      ui.updateStats({
+        status: stopTrainingFlag ? 'Training Stopped' : 'Training Complete!',
+        generation: learner.generation,
+        bestReward: learner.bestReward,
+        populationSize: config.learning.populationSize
+      });
+
+      if (typeof setWorldPaused === 'function') {
+        setWorldPaused(false);
+      }
+
+      if (documentHandle) {
+        const startBtn = documentHandle.getElementById('start-training');
+        const stopBtn = documentHandle.getElementById('stop-training');
+        if (startBtn) startBtn.disabled = false;
+        if (stopBtn) stopBtn.disabled = true;
+      }
+    });
+
+    ui.on('onStopTraining', () => {
+      stopTrainingFlag = true;
+      if (trainingManager) {
+        trainingManager.stop();
+      }
+      if (typeof setWorldPaused === 'function') {
+        setWorldPaused(false);
+      }
+      console.log('Stop training requested');
+    });
+
+    ui.on('onResetLearner', () => {
+      learner.generation = 0;
+      learner.bestReward = -Infinity;
+      learner.bestWeights = null;
+      learner.history = [];
+      learner.mu = new Array(learner.weightDims).fill(0);
+      learner.sigma = new Array(learner.weightDims).fill(config.learning.mutationStdDev);
+
+      ui.updateStats({
+        status: 'Learner Reset',
+        generation: 0,
+        bestReward: 0,
+        meanReward: 0
+      });
+
+      ui.drawLearningCurve([]);
+
+      console.log('Learner reset to initial state');
+    });
+
+    ui.on('onSavePolicy', () => {
+      const state = learner.save();
+      const json = JSON.stringify(state, null, 2);
+      const blob = new Blob([json], { type: 'application/json' });
+      const url = URL.createObjectURL(blob);
+      const a = documentHandle.createElement('a');
+      a.href = url;
+      a.download = `slime-policy-gen${learner.generation}.json`;
+      a.click();
+      URL.revokeObjectURL(url);
+      console.log('Policy saved!');
+    });
+
+    ui.on('onLoadPolicy', () => {
+      const input = documentHandle.createElement('input');
+      input.type = 'file';
+      input.accept = 'application/json';
+      input.onchange = (e) => {
+        const file = e.target.files?.[0];
+        if (!file) return;
+        const reader = new FileReader();
+        reader.onload = (event) => {
+          try {
+            const state = JSON.parse(event.target.result);
+            learner.load(state);
+            loadedPolicyInfo = {
+              filename: file.name,
+              generation: learner.generation,
+              bestReward: learner.bestReward,
+              timestamp: new Date().toLocaleString()
+            };
+
+            ui.updateStats({
+              status: 'Policy Loaded!',
+              generation: learner.generation,
+              bestReward: learner.bestReward
+            });
+            ui.drawLearningCurve(learner.history);
+            ui.showLoadedPolicyInfo(file.name, learner.generation, learner.bestReward);
+
+            console.log(`Policy loaded: ${file.name} (Gen ${learner.generation}, Reward: ${learner.bestReward.toFixed(2)})`);
+          } catch (err) {
+            console.error('Failed to load policy:', err);
+            alert('Failed to load policy file');
+          }
+        };
+        reader.readAsText(file);
+      };
+      input.click();
+    });
+
+    ui.on('onTestPolicy', () => {
+      const bestPolicy = learner.getBestPolicy();
+      if (!bestPolicy) {
+        alert('No trained policy available yet!');
+        return;
+      }
+      world.reset();
+      world.bundles.forEach((bundle) => {
+        bundle.controller = bestPolicy;
+        bundle.useController = true;
+      });
+      setLearningMode('play');
+      const infoStr = loadedPolicyInfo
+        ? `${loadedPolicyInfo.filename} (Gen ${loadedPolicyInfo.generation})`
+        : `current best (Gen ${learner.generation})`;
+      console.log(`Testing policy (ALL ${world.bundles.length} AGENTS): ${infoStr}`);
+    });
+
+    ui.on('onUsePolicy', () => {
+      const bestPolicy = learner.getBestPolicy();
+      if (!bestPolicy) {
+        alert('No policy loaded yet!');
+        return;
+      }
+      world.reset();
+      world.bundles.forEach((bundle) => {
+        bundle.controller = bestPolicy;
+        bundle.useController = true;
+      });
+      setLearningMode('play');
+      config.hud.showActions = true;
+      if (loadedPolicyInfo) {
+        console.log(`Using loaded policy (ALL ${world.bundles.length} AGENTS): ${loadedPolicyInfo.filename} (Gen ${loadedPolicyInfo.generation}, Reward: ${loadedPolicyInfo.bestReward.toFixed(2)})`);
+        console.log('💡 Tip: Watch all agents\' actions (T=turn, P=thrust, S=sense) with yellow borders.');
+        console.log('🤝 Multi-agent: All agents use the same policy and can learn from each other\'s trails!');
+      } else {
+        console.log(`Using current best policy (ALL ${world.bundles.length} AGENTS, Gen ${learner.generation})`);
+      }
+    });
+
+    console.log('Training UI initialized. Press [L] to toggle.');
+  }
+
+  function stopTraining() {
+    stopTrainingFlag = true;
+    if (trainingManager) {
+      trainingManager.stop();
+    }
+  }
+
+  return {
+    getLearningMode,
+    setLearningMode,
+    runEpisode,
+    ensureTrainingManager,
+    initializeTrainingUI,
+    stopTraining,
+    isTrainingStopped: () => stopTrainingFlag,
+    setStopTrainingFlag: (value) => {
+      stopTrainingFlag = Boolean(value);
+    }
+  };
+}


### PR DESCRIPTION
## Summary
- extract a reusable simulation loop core that handles delta-time clamping, phase execution, and frame scheduling
- update the main application to assemble simulation phases and rely on the shared loop utilities
- move the training orchestration, including runEpisode and UI wiring, into a dedicated core module for reuse

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e35e10fc08333807b7a52ec6d5284)