### PR TITLE
Document modular architecture and catalog legacy docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,26 @@
 # Slime-Bundle
 
-Slime-Bundle is a browser-based simulation that explores the emergent behavior of simple, resource-seeking agents ("bundles") in a dynamic 2D environment. It combines elements of plant ecology, reinforcement learning, and agent-based modeling to create a rich, interactive world.
+Slime-Bundle is a browser-based sandbox for exploring emergent behavior in swarms of resource-seeking agents ("bundles"). The refactored codebase separates rendering, simulation, and tooling into modular packages so you can iterate on ecology experiments, learning pipelines, or UI instrumentation without wading through a single monolithic script.
 
 ## Features
 
-*   **Complex Agent Behavior:** Agents exhibit a range of behaviors including foraging, trail-laying, and responding to environmental cues.
-*   **Dynamic Plant Ecology:** A fertility-based system governs resource distribution, creating a more natural and clustered environment.
-*   **Reinforcement Learning:** Agents can be trained using the Cross-Entropy Method (CEM) to learn effective foraging strategies.
-*   **Interactive Simulation:** A wide range of keyboard controls allow you to manipulate the simulation, toggle visualizations, and interact with the agents.
-*   **Highly Configurable:** The simulation's parameters are exposed in `config.js`, allowing you to experiment with different scenarios.
-*   **TC Snapshot Mode:** Load `profiles/universality/casual_universality_flex.json` to enable the deterministic Rule 110 runner and stream `tc.rule110.snapshot` manifests for manifest validation and headless reproductions.
+* **Modular Simulation Core:** The runtime is organized into focused modules for the world state, systems, UI wiring, and shared utilities under `src/`, making it easier to extend individual mechanics or replace subsystems without side effects.【F:src/index.js†L1-L23】【F:src/core/world.js†L1-L120】
+* **Dynamic Ecology:** Plant fertility, carrying capacity, and residual trail systems work together to produce clustered resources that react to agent pressure.【F:src/core/world.js†L41-L120】
+* **Multi-Agent Training:** A dedicated training module orchestrates synchronized episodes for every bundle, captures telemetry, and coordinates the Cross-Entropy Method (CEM) learner alongside the training UI controls.【F:src/core/training.js†L1-L140】【F:src/core/training.js†L175-L248】
+* **Interactive Simulation:** Keyboard and UI controls let you toggle sensing, gradients, mitosis, telemetry overlays, and training workflows while the render loop adapts to play vs. train modes.【F:src/core/simulationLoop.js†L1-L101】【F:trainingUI.js†L1-L120】
+* **Configurable Systems:** Parameters for ecology, sensing, rewards, HUD overlays, and learning live in `config.js` so experiments can be tuned without touching code.【F:config.js†L1-L260】
+
+## Project Structure
+
+```
+src/
+  core/         # world assembly, simulation loop orchestration, training coordinator
+  systems/      # discrete systems for movement, sensing, metabolism, mitosis, resources
+  ui/           # browser input and canvas managers
+  utils/        # math helpers and shared utilities
+```
+
+Legacy entry points (`app.js`, `controllers.js`, etc.) remain for backward compatibility, but new features should target the modular `src/` packages.
 
 ## Controls
 
@@ -33,27 +44,23 @@ Slime-Bundle is a browser-based simulation that explores the emergent behavior o
 
 ## Configuration
 
-The simulation's behavior is controlled by a central configuration file, `config.js`. This file exports a `CONFIG` object containing numerous parameters that you can modify to alter the simulation.
+`config.js` exports a single `CONFIG` object that drives ecology, autonomy, UI overlays, and training policies. Highlights:
 
-### Key Configuration Areas:
+* **`plantEcology`** – Enables the fertility-based resource system and its carrying-capacity logic.【F:config.js†L74-L145】
+* **`adaptiveReward`** – Optional adaptive reward calculations that scale payouts with search difficulty; toggle `enabled` to experiment without committing to the mechanic full-time.【F:config.js†L214-L230】
+* **`mitosis`** – Controls reproduction thresholds, lineage overlays, and population caps.【F:config.js†L308-L365】
+* **`learning`** – Configures CEM population sizes, mutation schedules, and episode horizons for bundled training runs.【F:config.js†L386-L474】
 
-*   **`plantEcology`**: Controls the fertility-based resource system. You can enable/disable it, change fertility parameters, and adjust seed dispersal mechanics.
-*   **`adaptiveReward`**: Manages the adaptive reward system. You can enable/disable it and tweak the parameters that determine how rewards are calculated.
-*   **`mitosis`**: Governs agent reproduction. You can set the energy threshold for mitosis, the cost, and the population limits.
-*   **`ai`**: A collection of parameters that control the agents' AI, including their sensory range, exploration behavior, and frustration mechanics.
-*   **`learning`**: Contains settings for the reinforcement learning system, such as the population size, mutation rate, and episode length.
+## Training Workflow
 
-## Learning System
+Press `L` to open the training dashboard and manage multi-agent learning sessions. Behind the scenes the training coordinator:
 
-The simulation includes a reinforcement learning system based on the **Cross-Entropy Method (CEM)**. This is a simple evolutionary algorithm that trains a linear policy for the agents.
+1. Resets the world and assigns the candidate policy to each bundle before an episode.【F:src/core/training.js†L25-L77】
+2. Steps every bundle in lock-step while capturing trail/signal telemetry and computing adaptive or fixed rewards per collection.【F:src/core/training.js†L92-L183】
+3. Hands reward aggregates back to the learner so CEM can rank elites and evolve the next generation.【F:src/core/training.js†L184-L248】
 
-### Training UI
+The UI surface lets you start/stop batches, save or load policies, and swap between play/test/train modes without restarting the simulation.【F:trainingUI.js†L45-L120】
 
-You can access the training UI by pressing the `L` key. The UI provides the following controls:
+## Documentation
 
-*   **Start Training:** Begins the training process. The simulation will run many episodes in the background to evaluate and improve the agents' policies.
-*   **Stop Training:** Halts the training process.
-*   **Save Policy:** Saves the current best policy to a JSON file.
-*   **Load Policy:** Loads a previously saved policy from a JSON file.
-*   **Test Best Policy:** Resets the simulation and applies the current best policy to the agents.
-*   **Reset Learner:** Resets the learning system to its initial state.
+Head to `docs/INDEX.md` for a curated map of maintained guides, experimental write-ups, and notes on legacy material that still references the pre-modular layout or HUD overlays.

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -1,0 +1,86 @@
+# Documentation Index
+
+This index highlights the modular architecture that now powers Slime-Bundle, points to living guides, and records legacy notes for write-ups that still describe the pre-refactor HUD or reward behavior.
+
+## Architecture Snapshot
+
+* **World & Systems:** `src/core/world.js` assembles bundles, resources, ecology regulators, and adaptive reward tracking into a cohesive world object that other systems consume.【F:src/core/world.js†L1-L120】
+* **Simulation Loop:** `src/core/simulationLoop.js` exposes reusable tick orchestration so play and training modes share a deterministic sequence of capture, update, and render phases.【F:src/core/simulationLoop.js†L1-L101】
+* **Training Orchestrator:** `src/core/training.js` coordinates synchronized multi-agent episodes, hooks in telemetry capture, and feeds aggregate returns back to the learner and UI.【F:src/core/training.js†L1-L248】
+
+## Maintained Guides
+
+* [Training Guide](TRAINING_GUIDE.md) – Covers the in-app control panel, generation workflow, and CEM learning loop from the operator perspective.【F:docs/TRAINING_GUIDE.md†L1-L104】
+* [Multi-Agent Guide](MULTI_AGENT_GUIDE.md) – Explains the shared-policy setup, reward aggregation, and cooperation dynamics introduced when both bundles learn together.【F:docs/MULTI_AGENT_GUIDE.md†L1-L140】
+* [Signal Field System Overview](SIGNAL_FIELD_SYSTEM_OVERVIEW.md) – Documents the experimental communication substrate, configuration knobs, and analytics hooks for signal-based coordination.【F:docs/SIGNAL_FIELD_SYSTEM_OVERVIEW.md†L1-L35】
+
+## Experimental & Legacy References
+
+The following files still describe mechanics or UI that diverge from the current modular stack. Use them as historical context only:
+
+| File | Topic | Legacy Note |
+| --- | --- | --- |
+| [README.md](../README.md) | Project overview | Updated in this pass to document the modular `src/` layout and opt-in adaptive rewards; prior copies implied a monolithic script and always-on rewards.【F:README.md†L1-L61】【F:README.md†L82-L123】 |
+| [ADAPTIVE_REWARD_IMPLEMENTATION_SUMMARY.md](ADAPTIVE_REWARD_IMPLEMENTATION_SUMMARY.md) | Adaptive rewards | Asserts the adaptive reward system is "fully functional" with permanent HUD overlays, which no longer matches the configurable deployment strategy.【F:docs/ADAPTIVE_REWARD_IMPLEMENTATION_SUMMARY.md†L5-L40】 |
+| [QUICK_START_ADAPTIVE_REWARDS.md](QUICK_START_ADAPTIVE_REWARDS.md) | Adaptive rewards | Guarantees a working HUD line and always-enabled adaptive payouts, overstating the current opt-in configuration.【F:docs/QUICK_START_ADAPTIVE_REWARDS.md†L3-L158】 |
+| [REWARD_SYSTEM_SUMMARY.md](REWARD_SYSTEM_SUMMARY.md) | Adaptive rewards | Presents adaptive rewards as the default reinforcement baseline and ties monitoring to HUD diagnostics that no longer exist.【F:docs/REWARD_SYSTEM_SUMMARY.md†L12-L188】 |
+| [REWARD_SYSTEM_IMPLEMENTATION_PLAN.md](REWARD_SYSTEM_IMPLEMENTATION_PLAN.md) | Adaptive rewards | Walks through retrofitting `app.js` with adaptive reward phases, reflecting the pre-modular layout and assuming mandatory activation.【F:docs/REWARD_SYSTEM_IMPLEMENTATION_PLAN.md†L90-L220】 |
+| [REWARD_DECISION_TREE.md](REWARD_DECISION_TREE.md) | Adaptive rewards | Troubleshooting steps rely on HUD readouts of adaptive stats and fixed gain-factor tuning paths from the legacy UI.【F:docs/REWARD_DECISION_TREE.md†L150-L220】 |
+| [MULTIPLE_RESOURCES_IMPLEMENTATION.md](MULTIPLE_RESOURCES_IMPLEMENTATION.md) | HUD cues | Testing checklist instructs operators to verify adaptive HUD averages that are no longer rendered by default.【F:docs/MULTIPLE_RESOURCES_IMPLEMENTATION.md†L124-L207】 |
+| [VISUAL_INDICATORS.md](VISUAL_INDICATORS.md) | HUD cues | Documents yellow HUD labels and policy badges that diverge from the refactored UI toolkit.【F:docs/VISUAL_INDICATORS.md†L11-L175】 |
+| [WHATS_NEW.md](WHATS_NEW.md) | HUD cues | Release notes ask testers to confirm dual policy labels in the HUD, which the new layout replaced.【F:docs/WHATS_NEW.md†L93-L123】 |
+| [INTEGRATION_COMPLETE.md](INTEGRATION_COMPLETE.md) | Module layout | Step-by-step instructions patch `app.js` directly instead of the modular `src/` packages, making it misleading for new contributions.【F:docs/INTEGRATION_COMPLETE.md†L56-L163】 |
+| [LEARNING_SYSTEM.md](LEARNING_SYSTEM.md) | Module layout | Lists legacy top-level modules and TODOs aimed at `app.js`, not the refactored architecture.【F:docs/LEARNING_SYSTEM.md†L9-L106】 |
+
+## Experimental Features
+
+* **Signal Field analytics** – Opt-in telemetry for channel coherence remains experimental; cross-verify terminology and screenshots before publishing externally.【F:docs/SIGNAL_FIELD_SYSTEM_OVERVIEW.md†L1-L35】
+* **TC resource overlay** – The Rule 110 integration scripts require manual toggles and console setup; treat the quickstart guide as experimental until the UI flow is redesigned.【F:docs/TC_RESOURCE_QUICKSTART.md†L1-L120】
+
+## Full Markdown Inventory
+
+Markdown assets currently tracked under `docs/` (including nested `notes/`) are listed below for quick reference.【3c409e†L1-L38】
+
+```
+ADAPTIVE_REWARD_IMPLEMENTATION_SUMMARY.md
+ANALYZER_SUMMARY.md
+ANALYZER_TOOLS_SUMMARY.md
+BATCH_ANALYZER_GUIDE.md
+DECAY_SYSTEM.md
+FIXES_APPLIED.md
+FLICKERING_FIX.md
+GRADIENT_IMPLEMENTATION_SUMMARY.md
+HUNGER_SYSTEM_GUIDE.md
+INTEGRATION_COMPLETE.md
+LEARNING_SYSTEM.md
+MITOSIS_IMPLEMENTATION.md
+MULTIPLE_RESOURCES_IMPLEMENTATION.md
+MULTI_AGENT_GUIDE.md
+OWN_TRAIL_PENALTY_GUIDE.md
+PLANT_ECOLOGY_GUIDE.md
+POLICY_ANALYZER_GUIDE.md
+POLICY_TRAINING_TIPS.md
+QUICK_START_ADAPTIVE_REWARDS.md
+QUICK_TEST.md
+RESOURCE_ECOLOGY_GUIDE.md
+REWARD_DECISION_TREE.md
+REWARD_SYSTEM_IMPLEMENTATION_PLAN.md
+REWARD_SYSTEM_SUMMARY.md
+SCENT_GRADIENT_GUIDE.md
+SENSING_REBALANCE.md
+SIGNAL_FIELD_SYSTEM_OVERVIEW.md
+TC_BROWSER_GUIDE.md
+TC_OVERLAY_FIX.md
+TC_RESOURCE_INTEGRATION.md
+TC_RESOURCE_QUICKSTART.md
+TRAINING_GUIDE.md
+VISUAL_INDICATORS.md
+WHATS_NEW.md
+notes/casual_universality_flex.md
+notes/tc_channel_design.md
+notes/tc_performance.md
+```
+
+## Review Request
+
+Please schedule a product-owner review focused on HUD terminology, screenshots, and adaptive reward messaging so the documentation matches the refactored UI. Confirm whether new captures or vocabulary adjustments are needed before the next release cut.


### PR DESCRIPTION
## Summary
- refresh the README to highlight the modular src layout, multi-agent training coordinator, and optional adaptive rewards
- add a docs/INDEX.md that maps maintained guides, flags legacy adaptive-reward/HUD write-ups, and lists all markdown assets
- request a product-owner review on HUD terminology and screenshots to align with the refactored UI

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e5c2964a08333844bc9770854659a)