### PR TITLE
Guard config browser hooks for node regressions

### DIFF
--- a/analysis/post_modularization_regression.md
+++ b/analysis/post_modularization_regression.md
@@ -1,0 +1,29 @@
+# Post-Modularization Regression Notes
+
+## Summary
+- Automated node-based suites completed via the shared ESM loader and passed without failures.
+- Manual browser simulation could not be executed in the container environment; a follow-up interactive review is still required.
+
+## Test Matrix
+| Command | Result |
+| --- | --- |
+| `node --loader ./test/esm-loader.mjs test/movement.test.js` | ✔ Passed |
+| `node --loader ./test/esm-loader.mjs test/metabolism.test.js` | ✔ Passed |
+| `node --loader ./test/esm-loader.mjs test/decay.test.js` | ✔ Passed |
+| `node --loader ./test/esm-loader.mjs test/steering.test.js` | ✔ Passed |
+| `node --loader ./test/esm-loader.mjs test/controllerAction.test.js` | ✔ Passed |
+| `node --loader ./test/esm-loader.mjs test/resourceSystem.test.js` | ✔ Passed |
+| `node --loader ./test/esm-loader.mjs test/sensing.test.js` | ✔ Passed |
+| `node --loader ./test/esm-loader.mjs test/mitosis.test.js` | ✔ Passed |
+| `node --loader ./test/esm-loader.mjs test/test-rule110.js` | ✔ Passed |
+| `node --loader ./test/esm-loader.mjs test/test-tape.js` | ✔ Passed |
+| `node --loader ./test/esm-loader.mjs test/test-tc-disabled.js` | ✔ Passed |
+| `node --loader ./test/esm-loader.mjs test-adaptive-rewards.js` | ✔ Passed with expected inline machine warning |
+
+## Lessons Learned
+- `config.js` must remain import-safe for Node-based utilities. Guarding DOM access behind browser checks prevents regression scripts from crashing when a window or document is unavailable.
+- The TC configuration still references on-disk machine tables; falling back to inline descriptors avoids noisy warnings during headless runs and should be prioritized.
+
+## Follow-Up Actions
+- [ ] Schedule a manual simulation review in a browser build to validate UI wiring, hotkeys, and adaptive reward overlays.
+- [ ] Track an issue to provide inline TC machine descriptors (or loader stubs) so regression scripts no longer warn about missing filesystem access.


### PR DESCRIPTION
## Summary
- guard the config panel helpers and hotkey wiring so config.js can load in Node-based regression scripts
- make localStorage usage optional to avoid ReferenceErrors outside the browser
- add post-modularization regression notes capturing the test matrix, lessons learned, and follow-up actions

## Testing
- node --loader ./test/esm-loader.mjs test/movement.test.js
- node --loader ./test/esm-loader.mjs test/metabolism.test.js
- node --loader ./test/esm-loader.mjs test/decay.test.js
- node --loader ./test/esm-loader.mjs test/steering.test.js
- node --loader ./test/esm-loader.mjs test/controllerAction.test.js
- node --loader ./test/esm-loader.mjs test/resourceSystem.test.js
- node --loader ./test/esm-loader.mjs test/sensing.test.js
- node --loader ./test/esm-loader.mjs test/mitosis.test.js
- node --loader ./test/esm-loader.mjs test/test-rule110.js
- node --loader ./test/esm-loader.mjs test/test-tape.js
- node --loader ./test/esm-loader.mjs test/test-tc-disabled.js
- node --loader ./test/esm-loader.mjs test-adaptive-rewards.js

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e5fdb1f00833393af682fc96fa1f0)