### PR TITLE
Integrate participation steering forces with decay

### DIFF
--- a/app.js
+++ b/app.js
@@ -1099,6 +1099,14 @@ import { collectResource } from './src/systems/resourceSystem.js';
     };
 
     const updateAgentsPhase = ({ dt, tickContext }) => {
+      try {
+        ParticipationManager.update(dt);
+      } catch (error) {
+        if (CONFIG?.participation?.debugLog && typeof console !== 'undefined' && console.debug) {
+          console.debug('[Participation] update error:', error);
+        }
+      }
+
       for (let i = 0; i < World.bundles.length; i++) {
         for (let j = i + 1; j < World.bundles.length; j++) {
           const a = World.bundles[i];


### PR DESCRIPTION
## Summary
- update the agent phase to tick the participation manager with debug-safe logging
- add distance falloff, temporal fading, and safe clamping to participation force computation while exposing the last force vector
- inject participation force vectors into the steering pipeline before normalization and notify bundle hooks

## Testing
- node test/steering.test.js

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e739c29848333a1475ccfc11f9544)