### PR TITLE
Integrate participation energy chi adjustments

### DIFF
--- a/src/ui/inputManager.js
+++ b/src/ui/inputManager.js
@@ -140,7 +140,13 @@ export function initializeInputManager({
     switch (e.code) {
       case 'Space':
         if (world) {
-          world.paused = !world.paused;
+          if (typeof world.togglePause === 'function') {
+            world.togglePause();
+          } else if (typeof world.setPaused === 'function') {
+            world.setPaused(!world.paused);
+          } else {
+            world.paused = !world.paused;
+          }
           e.preventDefault();
         }
         break;


### PR DESCRIPTION
## Summary
- add chi mutation helpers and participation energy sampling to the main world update
- pause or reset participation energy when the world pauses or resets and expose controlled pause helpers
- route spacebar pausing through the new world pause API for input handling

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e760248248333b89eaba0e1725a6d)