### PR TITLE
Add participation debug telemetry instrumentation

### DIFF
--- a/config.js
+++ b/config.js
@@ -99,6 +99,7 @@ const loadTapeMachinesFromConfig = (tcConfig = {}) => {
 };
 
 export const CONFIG = {
+  debug: false,
   // === Physics & Core Mechanics ===
   startChi: 15,
   baseDecayPerSecond: 0.10,
@@ -537,6 +538,9 @@ function initSnapshotsOnce() {
 
 
 export const CONFIG_SCHEMA = {
+  Diagnostics: {
+    debug: { label: "Debug mode", type: "boolean" }
+  },
   Metabolism: {
     startChi: { label: "Start χ", min: 0, max: 200, step: 1 },
     baseDecayPerSecond: { label: "Leak χ/sec", min: 0, max: 2, step: 0.01 },
@@ -803,6 +807,7 @@ export const CONFIG_SCHEMA = {
 };
 
 const CONFIG_HINTS = {
+  debug: "Enable debug instrumentation and telemetry forwarding.",
   // Metabolism
   startChi: "Starting chi for freshly spawned agents.",
   baseDecayPerSecond: "Passive chi leak each second.",

--- a/src/core/world.js
+++ b/src/core/world.js
@@ -2,6 +2,7 @@ import { CONFIG } from '../../config.js';
 import { SignalField } from '../../signalField.js';
 import { SignalResponseAnalytics } from '../../analysis/signalResponseAnalytics.js';
 import { TcScheduler, TcStorage, TcRandom } from '../../tcStorage.js';
+import ParticipationManager from '../systems/participation.js';
 
 const clampValue = (value, min, max) => Math.max(min, Math.min(max, value));
 
@@ -75,6 +76,9 @@ export function createWorld(context) {
       Trail.clear();
       SignalField.clear();
       SignalResponseAnalytics.reset();
+      if (ParticipationManager && typeof ParticipationManager.resetState === 'function') {
+        ParticipationManager.resetState({ reason: 'world-reset' });
+      }
       TcStorage.clear();
       TcScheduler.reset();
       setGlobalTick(0);


### PR DESCRIPTION
## Summary
- add debug buffers and telemetry emitters to the participation system gated behind CONFIG.debug
- reset participation state on pauses, resumes, and world resets to keep deterministic runs
- expose a CONFIG.debug toggle and diagnostics schema entry for the new instrumentation hooks

## Testing
- node --experimental-loader ./test/esm-loader.mjs test/steering.test.js

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e80001014833383f98fd71b1b6215)