### PR TITLE
Improve mobile layout responsiveness

### DIFF
--- a/app.js
+++ b/app.js
@@ -77,15 +77,20 @@ import { MetricsTracker } from './src/core/metricsTracker.js';
     let canvasHeight = innerHeight;
 
     const getAvailableSize = () => {
+      const viewport = typeof window !== 'undefined' ? window.visualViewport : null;
+      const viewportWidth = viewport ? Math.floor(viewport.width) : innerWidth;
+      const viewportHeight = viewport ? Math.floor(viewport.height) : innerHeight;
+
       const configPanel = document.getElementById("config-panel");
       const panelOpen = configPanel && configPanel.style.display !== "none";
-      const panelWidth = panelOpen ? 360 : 0; // Config panel width
-      // Canvas now fills full viewport, HUD/Dashboard are drawn on top
+      const maxPanelWidth = panelOpen ? 360 : 0; // Config panel width when space permits
+      const availableWidth = Math.max(0, viewportWidth - 80);
+      const panelWidth = panelOpen ? Math.min(maxPanelWidth, availableWidth) : 0;
 
       return {
-        width: innerWidth - panelWidth,
-        height: innerHeight,
-        panelWidth: panelWidth,
+        width: Math.max(0, viewportWidth - panelWidth),
+        height: viewportHeight,
+        panelWidth,
         topReserve: 0
       };
     };

--- a/index.html
+++ b/index.html
@@ -5,8 +5,19 @@
   <title>Essence Engine v0.0 — minimal viz up</title>
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <style>
-    html, body { margin: 0; padding: 0; background: #000; height: 100%; overflow: hidden; }
-    canvas { display: block; }
+    html, body {
+      margin: 0;
+      padding: 0;
+      background: #000;
+      height: 100%;
+      min-height: 100dvh;
+      overflow: hidden;
+      overscroll-behavior: contain;
+    }
+    canvas {
+      display: block;
+      touch-action: none;
+    }
     /* Optional: crisp monospace HUD */
     @font-face { font-family: ui-mono; src: local("Consolas"), local("Menlo"), local("Monaco"); }
     #hud-container, #dashboard-container {
@@ -16,17 +27,18 @@
       background: rgba(0, 0, 0, 0.75);
       padding: 10px;
       border-bottom: 1px solid rgba(0, 255, 136, 0.3);
+      backdrop-filter: blur(6px);
     }
     #hud-container {
       position: fixed;
-      top: 0;
+      top: env(safe-area-inset-top, 0px);
       left: 0;
       right: 0;
       z-index: 1000;
     }
     #dashboard-container {
       position: fixed;
-      top: 0;
+      top: env(safe-area-inset-top, 0px);
       left: 0;
       right: 0;
       z-index: 1000;
@@ -60,14 +72,14 @@
     }
     #hotkey-strip {
       position: fixed;
-      bottom: 0;
+      bottom: env(safe-area-inset-bottom, 0px);
       left: 0;
       right: 0;
       background: rgba(0, 0, 0, 0.85);
       color: #00ff88;
       font-family: ui-mono, monospace;
       font-size: 11px;
-      padding: 8px 12px;
+      padding: 8px 12px calc(8px + env(safe-area-inset-bottom, 0px));
       border-top: 1px solid rgba(0, 255, 136, 0.3);
       z-index: 2000;
       display: flex;
@@ -103,11 +115,125 @@
       height: 16px;
       background: rgba(0, 255, 136, 0.2);
     }
+
+    #mobile-overlay-toggle {
+      position: fixed;
+      right: 12px;
+      bottom: calc(12px + env(safe-area-inset-bottom, 0px));
+      z-index: 2100;
+      display: none;
+      align-items: center;
+      gap: 8px;
+      padding: 10px 14px;
+      border: 1px solid rgba(0, 255, 136, 0.4);
+      border-radius: 999px;
+      background: rgba(0, 0, 0, 0.85);
+      color: #88ffbb;
+      font-family: ui-mono, monospace;
+      font-size: 12px;
+      letter-spacing: 0.02em;
+      cursor: pointer;
+      transition: background 0.2s ease, color 0.2s ease;
+    }
+
+    #mobile-overlay-toggle:focus-visible {
+      outline: 2px solid rgba(0, 255, 136, 0.6);
+      outline-offset: 2px;
+    }
+
+    #mobile-overlay-toggle[aria-pressed="true"] {
+      background: rgba(0, 40, 24, 0.85);
+      color: #b4ffd7;
+    }
+
+    body.is-mobile #mobile-overlay-toggle {
+      display: inline-flex;
+    }
+
+    body.is-mobile #hud-container,
+    body.is-mobile #dashboard-container {
+      max-height: min(60dvh, 420px);
+      margin: 0 auto;
+      width: min(640px, calc(100vw - 24px));
+      box-shadow: 0 12px 24px rgba(0, 0, 0, 0.45);
+      border-radius: 10px;
+      border: 1px solid rgba(0, 255, 136, 0.2);
+      backdrop-filter: blur(8px);
+      transition: opacity 0.2s ease, transform 0.2s ease;
+    }
+
+    body.is-mobile #hud-container {
+      top: calc(env(safe-area-inset-top, 0px) + 10px);
+    }
+
+    body.is-mobile #dashboard-container {
+      top: calc(env(safe-area-inset-top, 0px) + 14px + var(--hud-offset, 0px));
+    }
+
+    body.is-mobile:not(.mobile-overlays-open) #hud-container,
+    body.is-mobile:not(.mobile-overlays-open) #dashboard-container {
+      opacity: 0;
+      pointer-events: none;
+      transform: translateY(-12px);
+      transition: opacity 0.2s ease, transform 0.2s ease;
+    }
+
+    body.is-mobile.mobile-overlays-open #hud-container,
+    body.is-mobile.mobile-overlays-open #dashboard-container {
+      opacity: 1;
+      pointer-events: auto;
+      transform: translateY(0);
+      transition: opacity 0.2s ease, transform 0.2s ease;
+    }
+
+    body.is-mobile #hotkey-strip {
+      font-size: 10px;
+      gap: 8px;
+      padding: 6px 10px calc(10px + env(safe-area-inset-bottom, 0px));
+      overflow-x: auto;
+      -webkit-overflow-scrolling: touch;
+      scroll-snap-type: x proximity;
+      transition: transform 0.24s ease, opacity 0.18s ease;
+    }
+
+    body.is-mobile #hotkey-strip .hotkey-item {
+      flex: 0 0 auto;
+      scroll-snap-align: start;
+    }
+
+    body.is-mobile:not(.mobile-overlays-open) #hotkey-strip {
+      transform: translateY(120%);
+      opacity: 0;
+      pointer-events: none;
+    }
+
+    body.is-mobile.mobile-overlays-open #hotkey-strip {
+      transform: translateY(0);
+      opacity: 1;
+      pointer-events: auto;
+    }
+
+    @media (max-width: 768px) {
+      #dashboard-container table {
+        font-size: 10px;
+      }
+
+      .hotkey-desc {
+        display: none;
+      }
+
+      .hotkey-key {
+        min-width: 16px;
+      }
+    }
   </style>
 </head>
 <body>
   <div id="hud-container"></div>
   <div id="dashboard-container" class="hidden"></div>
+  <button id="mobile-overlay-toggle" type="button" aria-pressed="false" aria-controls="hud-container dashboard-container hotkey-strip">
+    HUD &amp; Hotkeys
+  </button>
   <div id="hotkey-strip">
     <div class="hotkey-item"><span class="hotkey-key">K</span><span class="hotkey-desc">Toggle Hotkeys</span></div>
     <div class="hotkey-divider"></div>

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,114 @@
 // Loads the existing app.js side effects and re-exports its window globals.
 import '../app.js';
 
+function setupMobileOptimizations() {
+  if (typeof window === 'undefined') return;
+
+  const body = document.body;
+  const root = document.documentElement;
+  const toggleButton = document.getElementById('mobile-overlay-toggle');
+  const hud = document.getElementById('hud-container');
+
+  if (!body || !root || !toggleButton) {
+    return;
+  }
+
+  let overlaysOpen = false;
+  let lastIsMobile = null;
+
+  if (typeof window.matchMedia !== 'function') {
+    return;
+  }
+
+  const widthQuery = window.matchMedia('(max-width: 768px)');
+  const pointerQuery = window.matchMedia('(pointer: coarse)');
+
+  const ensureHudOffset = () => {
+    if (!body.classList.contains('is-mobile') || !overlaysOpen || !hud) {
+      root.style.setProperty('--hud-offset', '0px');
+      return;
+    }
+
+    const hudRect = hud.getBoundingClientRect();
+    const offset = Math.max(0, Math.ceil(hudRect.height + 12));
+    root.style.setProperty('--hud-offset', `${offset}px`);
+  };
+
+  const applyOverlayState = () => {
+    const isMobile = body.classList.contains('is-mobile');
+
+    if (!isMobile) {
+      body.classList.remove('mobile-overlays-open');
+      toggleButton.setAttribute('aria-pressed', 'false');
+      ensureHudOffset();
+      return;
+    }
+
+    body.classList.toggle('mobile-overlays-open', overlaysOpen);
+    toggleButton.setAttribute('aria-pressed', overlaysOpen ? 'true' : 'false');
+    window.requestAnimationFrame(ensureHudOffset);
+  };
+
+  const prefersMobile = () => widthQuery.matches || pointerQuery.matches;
+
+  const handleMobileChange = () => {
+    const nextIsMobile = prefersMobile();
+    body.classList.toggle('is-mobile', nextIsMobile);
+
+    if (nextIsMobile !== lastIsMobile) {
+      overlaysOpen = nextIsMobile ? false : true;
+      lastIsMobile = nextIsMobile;
+    }
+
+    applyOverlayState();
+  };
+
+  const attachMediaListener = (query) => {
+    if (!query) return;
+    if (typeof query.addEventListener === 'function') {
+      query.addEventListener('change', handleMobileChange);
+    } else if (typeof query.addListener === 'function') {
+      query.addListener(handleMobileChange);
+    }
+  };
+
+  attachMediaListener(widthQuery);
+  attachMediaListener(pointerQuery);
+
+  toggleButton.addEventListener('click', () => {
+    overlaysOpen = !overlaysOpen;
+    applyOverlayState();
+  });
+
+  window.addEventListener('resize', () => {
+    handleMobileChange();
+    if (body.classList.contains('is-mobile') && overlaysOpen) {
+      window.requestAnimationFrame(ensureHudOffset);
+    }
+  }, { passive: true });
+
+  if (window.visualViewport) {
+    const handleViewportChange = () => {
+      window.requestAnimationFrame(() => {
+        handleMobileChange();
+        if (typeof window.resizeCanvas === 'function') {
+          window.resizeCanvas();
+        }
+        if (body.classList.contains('is-mobile') && overlaysOpen) {
+          ensureHudOffset();
+        }
+      });
+    };
+
+    window.visualViewport.addEventListener('resize', handleViewportChange);
+    window.visualViewport.addEventListener('scroll', handleViewportChange);
+  }
+
+  handleMobileChange();
+}
+
+setupMobileOptimizations();
+
 if (typeof window !== 'undefined' && typeof window.resizeCanvas === 'function') {
   window.resizeCanvas();
 }


### PR DESCRIPTION
## Summary
- add mobile-safe layout rules, safe-area support, and a HUD toggle button to declutter small screens
- introduce mobile overlay controls and viewport listeners so HUD, hotkeys, and canvas respond to touch devices
- compute canvas sizing from the visual viewport and clamp config panel width for narrow displays

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f67254df8833381ad511ff9769627)